### PR TITLE
Sync task types.

### DIFF
--- a/volume/sync.py
+++ b/volume/sync.py
@@ -1,7 +1,6 @@
 import os
 
 import gazu
-import pymongo
 from avalon import io as avalon
 
 
@@ -98,9 +97,10 @@ def main():
                     )
                 )
                 existing_project["config"]["tasks"] = tasks
-                client = pymongo.MongoClient(os.environ["AVALON_MONGO"])
-                db = client["avalon"]
-                db[project["name"]].save(existing_project)
+                os.environ["AVALON_PROJECT"] = project["name"]
+                avalon.uninstall()
+                avalon.install()
+                avalon.replace_one({"type": "project"}, existing_project)
 
             continue
 


### PR DESCRIPTION
Fix for #31

I'm not sure about the implementation since its using pymongo to get the Mongo collection, but doing a ```.save()``` on the collection is the easiest way of updating I could find.

Maybe we need to expose a method in avalon-core that returns the collection, to avoid using pymongo?