### PR TITLE
Fix terminal environment

### DIFF
--- a/volume/terminal.bat
+++ b/volume/terminal.bat
@@ -1,11 +1,13 @@
 @echo off
 
 set AVALON_MONGO=mongodb://192.168.99.100:27017
+set AVALON_CORE=%~dp0git\avalon-core
+set AVALON_LAUNCHER=%~dp0git\avalon-launcher
 set PATH=%~dp0;%~dp0bin\windows\python36;%PATH%
 
 :: Expose Python libraries
-set PYTHONPATH=%~dp0git\avalon-core
-set PYTHONPATH=%~dp0git\avalon-launcher;%PYTHONPATH%
+set PYTHONPATH=%AVALON_CORE%
+set PYTHONPATH=%AVALON_LAUNCHER%;%PYTHONPATH%
 set PYTHONPATH=%~dp0git\mindbender-config;%PYTHONPATH%
 set PYTHONPATH=%~dp0git\pyblish-base;%PYTHONPATH%
 set PYTHONPATH=%~dp0git\pyblish-qml;%PYTHONPATH%

--- a/volume/terminal.sh
+++ b/volume/terminal.sh
@@ -7,11 +7,13 @@ if [[ -z $WORKDIR ]]; then
 fi
 
 export AVALON_MONGO=mongodb://127.0.0.1:27017
+export AVALON_CORE=$WORKDIR/git/avalon-core
+export AVALON_LAUNCHER=$WORKDIR/git/avalon-launcher
 export PATH=$WORKDIR:$PATH
 
 # Expose Python libraries
-export PYTHONPATH=$WORKDIR/git/avalon-core
-export PYTHONPATH=$WORKDIR/git/avalon-launcher:$PYTHONPATH
+export PYTHONPATH=$AVALON_CORE
+export PYTHONPATH=$AVALON_LAUNCHER:$PYTHONPATH
 export PYTHONPATH=$WORKDIR/git/mindbender-config:$PYTHONPATH
 export PYTHONPATH=$WORKDIR/git/pyblish-base:$PYTHONPATH
 export PYTHONPATH=$WORKDIR/git/pyblish-qml:$PYTHONPATH


### PR DESCRIPTION
**Problem**

You cant override the ```PYTHONPATH``` for development because ```AVALON_CORE``` and ```AVALON_LAUNCHER``` gets first priority.

**Solution**

Use ```AVALON_CORE``` and ```AVALON_LAUNCHER``` to setup the terminal environment.